### PR TITLE
Load text domain later

### DIFF
--- a/amnesty-salesforce-connector.php
+++ b/amnesty-salesforce-connector.php
@@ -104,14 +104,12 @@ class Connector {
 	 * Bind hooks
 	 */
 	public function __construct() {
-		$this->data = get_plugin_data( __FILE__ );
-
 		add_filter( 'translatable_packages', [ $this, 'register_translatable_package' ], 12 );
 
 		add_action( 'all_admin_notices', [ $this, 'check_dependencies' ] );
 
-		add_action( 'plugins_loaded', [ $this, 'textdomain' ] );
 		add_action( 'plugins_loaded', [ $this, 'boot' ], 1 );
+		add_action( 'init', [ $this, 'textdomain' ] );
 		add_action( 'init', [ $this, 'var' ] );
 		add_action( 'parse_request', [ $this, 'request' ] );
 		add_action( 'init', [ $this, 'rewrite' ], 10 );
@@ -170,6 +168,8 @@ class Connector {
 	 * @return void
 	 */
 	public function textdomain(): void {
+		$this->data = get_plugin_data( __FILE__ );
+
 		load_plugin_textdomain( 'aisc', false, basename( __DIR__ ) . '/languages' );
 	}
 


### PR DESCRIPTION
Fixes #4

steps to test:
- before checkout
- be on wp 6.7
- make sure the plugin is active
- install and activate query monitor
- view the site
- see the deprecation notice from WP Core
- checkout this pr
- reload the site
- the deprecation notice should disappear
- the plugin should still function correctly
- the aip text domain should still load correctly (check via query monitor on non-EN)